### PR TITLE
Definisjonsgrunnlag viser samme lista med koder to ganger

### DIFF
--- a/__snapshots__/data.test.js.snap
+++ b/__snapshots__/data.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`build/kodetre.json har antall rader 1`] = `166078`;
+exports[`build/kodetre.json har antall rader 1`] = `166079`;
 
 exports[`build/kodetre.json har forventede nøkler 1`] = `undefined`;
 
-exports[`build/kodetre_postgre.json har antall rader 1`] = `166079`;
+exports[`build/kodetre_postgre.json har antall rader 1`] = `166080`;
 
 exports[`build/kodetre_postgre.json har forventede nøkler 1`] = `undefined`;
 
-exports[`build/mangler_data.json har antall rader 1`] = `160939`;
+exports[`build/mangler_data.json har antall rader 1`] = `160940`;
 
 exports[`build/mangler_data.json har forventede nøkler 1`] = `undefined`;
 
@@ -24,19 +24,19 @@ exports[`data/ar_diagnostisk_art.json har antall rader 1`] = `1172`;
 
 exports[`data/ar_diagnostisk_art.json har forventede nøkler 1`] = `undefined`;
 
-exports[`data/ar_taxon.json har antall rader 1`] = `157943`;
+exports[`data/ar_taxon.json har antall rader 1`] = `157944`;
 
 exports[`data/ar_taxon.json har forventede nøkler 1`] = `undefined`;
 
-exports[`data/ar_taxon_to_json.json har antall rader 1`] = `157943`;
+exports[`data/ar_taxon_to_json.json har antall rader 1`] = `157944`;
 
 exports[`data/ar_taxon_to_json.json har forventede nøkler 1`] = `undefined`;
 
-exports[`data/full.json har antall rader 1`] = `166077`;
+exports[`data/full.json har antall rader 1`] = `166078`;
 
 exports[`data/full.json har forventede nøkler 1`] = `undefined`;
 
-exports[`data/full_med_graf.json har antall rader 1`] = `166077`;
+exports[`data/full_med_graf.json har antall rader 1`] = `166078`;
 
 exports[`data/full_med_graf.json har forventede nøkler 1`] = `undefined`;
 
@@ -52,7 +52,7 @@ exports[`data/inn_bbox.json har antall rader 1`] = `5061`;
 
 exports[`data/inn_bbox.json har forventede nøkler 1`] = `undefined`;
 
-exports[`data/metabase_med_bbox.json har antall rader 1`] = `166077`;
+exports[`data/metabase_med_bbox.json har antall rader 1`] = `166078`;
 
 exports[`data/metabase_med_bbox.json har forventede nøkler 1`] = `undefined`;
 

--- a/steg/2/na_hovedtype.js
+++ b/steg/2/na_hovedtype.js
@@ -39,12 +39,10 @@ hovedtyper.forEach(ht => {
   me.definisjonsgrunnlag.kode =
     kode_hovedtype.definisjonsgrunnlag.prefiks + "-" + ht["GrL"].trim()
   me.definisjonsgrunnlag.tittel = { nb: ht["Definisjonsgrunnlag-tekst"] }
-  me.definisjonsgrunnlag.undertittel = { nb: ht["Definisjonsgrunnlag"] }
   me.prosedyrekategori = {}
   me.prosedyrekategori.kode =
     kode_hovedtype.prosedyrekategori.prefiks + ht["PrK"]
   me.prosedyrekategori.tittel = { nb: ht["PrK-tekst"].trim() }
-  me.prosedyrekategori.undertittel = { nb: ht["Prosedyrekategori"] }
   me.nin1 = ht["NiN[1] "]
   r[typesystem.natursystem.leggTilPrefiks(ht.HTK)] = me
 })

--- a/steg/3/na_definisjonsgrunnlag.js
+++ b/steg/3/na_definisjonsgrunnlag.js
@@ -14,13 +14,8 @@ Object.keys(hovedtyper).forEach(kode => {
     r[pkkode] = {
       foreldre: [typesystem.natursystem.hovedtype.definisjonsgrunnlag.prefiks],
       tittel: dg.tittel,
-      undertittel: {
-        nb: "Definisjonsgrunnlag"
-      },
-      barn: []
+      nivå: "definisjonsgrunnlag"
     }
-
-  r[pkkode].barn.push(kode)
 })
 
 io.skrivDatafil(__filename, r)

--- a/steg/3/na_prosedyrekategori.js
+++ b/steg/3/na_prosedyrekategori.js
@@ -14,13 +14,8 @@ Object.keys(hovedtyper).forEach(kode => {
     r[pkkode] = {
       foreldre: [typesystem.natursystem.hovedtype.prosedyrekategori.prefiks],
       tittel: pk.tittel,
-      undertittel: {
-        nb: "Prosedyrekategori"
-      },
-      barn: []
+      nivå: "prosedyrekategori"
     }
-
-  r[pkkode].barn.push(kode)
 })
 
 io.skrivDatafil(__filename, r)


### PR DESCRIPTION
Relasjoner fra prosedyrekategori og definisjonsgrunnlag dukker både opp som relasjoner og barn.

Barn bør fjernes

#Duplikat av [ratatouille#386](https://github.com/Artsdatabanken/ratatouille/issues/386)

```json
{
  "barn": {
    "NA_I1": {
      "farge": "#bd3243",
      "sti": "na/i/1",
      "tittel": {
        "nb": "Snø- og isdekt fastmark"
      }
    }
  },
  "farge": "#66c2bc",
  "graf": {
    "hovedtype": {
      "NA_I1": {
        "erSubset": true,
        "farge": "#bd3243",
        "sti": "na/i/1",
        "tittel": {
          "nb": "Snø- og isdekt fastmark"
        }
      }
    }
  },
  "sti": "na/ht/dg/0",
  "tittel": {
    "nb": "normal hovedtype"
  },
  "undertittel": {
    "nb": "Definisjonsgrunnlag"
  }
}

```