### PR TITLE
Include datasets of type raster indexed

### DIFF
--- a/steg/09/metabase_med_bbox.js
+++ b/steg/09/metabase_med_bbox.js
@@ -31,7 +31,7 @@ let ukjentBbox = 0
 // Dvs. at rotkatalog betraktes som klasse av data, eks. gradient eller trinn
 const mbtiles = readMbtiles()
 
-const sourceTypes = ["vector", "raster.indexed"]
+const sourceTypes = ["vector", "raster.indexed", "raster.gradient"]
 sourceTypes.forEach(source => addViz(source))
 
 function addViz(klasse) {


### PR DESCRIPTION
- continuous data normalized to 8/16 or 24-bit range (0-255)
- stored in png files inside mbtiles