### PR TITLE
Pakk ut alle basistrinn for grunntyper og hovedtyper

### DIFF
--- a/steg/06/na_med_basistrinn_relasjon.js
+++ b/steg/06/na_med_basistrinn_relasjon.js
@@ -27,14 +27,21 @@ Object.keys(basistrinn).forEach(grunntype => {
     const hovedtype = mor(grunntype)
     const lkmkode = mor(mi)
     const lkm = na[lkmkode]
-    relasjon(na[grunntype], lkm.tittel.nb, mi, null)
-    ht[hovedtype] = lkmkode
+    relasjon(na[grunntype], lkm.tittel.nb, mi, "definerer")
+    if (!ht[hovedtype]) ht[hovedtype] = {}
+    ht[hovedtype][lkmkode] = true
   })
 })
 
+delete ht["NN-NA"]
+
+console.log(ht["NN-NA-T1"])
 Object.keys(ht).forEach(hovedtype => {
-  relasjon(na[hovedtype], "defineres av", ht[hovedtype], "definerer")
+  Object.keys(ht[hovedtype]).forEach(lkm =>
+    relasjon(na[hovedtype], "defineres av", lkm, "definerer")
+  )
 })
+
 /*Object.keys(lkm).forEach(kode => {
   relasjon(na[kode], "definerer", lkm[kode], "defineres av")
 })*/

--- a/steg/13/metabase_kartformat.js
+++ b/steg/13/metabase_kartformat.js
@@ -27,7 +27,6 @@ sourceTypes.forEach(source => addKartformat(source))
 normaliserGradienter()
 if (ukjentBbox > 0) log.info("bbox for '" + ukjentBbox + "' koder.")
 zoomlevels(typesystem.rotkode)
-
 io.skrivDatafil(__filename, tre)
 
 function readMbtiles() {


### PR DESCRIPTION
* Bare første trinn dukket opp på hovedtyper
* LKMene hadde ingen direkte kobling tilbake til grunntypene, nå er det overflod